### PR TITLE
[Fabric 1.20.1] Adding compat for simple copper pipes - support dripping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -25,6 +25,14 @@ repositories {
 		name = 'ParchmentMC'
 		url = 'https://maven.parchmentmc.org'
 	}
+
+    maven {
+        name = 'Modrinth'
+        url = 'https://api.modrinth.com/maven'
+        content {
+            includeGroup 'maven.modrinth'
+        }
+    }
 }
 
 fabricApi {
@@ -42,6 +50,8 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+    modImplementation "maven.modrinth:simple-copper-pipes:RMObPif0" // 1.20.1-1.16.1
 }
 
 processResources {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/paddedshaman/blazingbamboo/BlazingBamboo.java
+++ b/src/main/java/net/paddedshaman/blazingbamboo/BlazingBamboo.java
@@ -5,6 +5,7 @@ import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
 import net.fabricmc.fabric.api.registry.FuelRegistry;
 import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -14,6 +15,7 @@ import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.feature.configurations.RandomPatchConfiguration;
 import net.paddedshaman.blazingbamboo.block.BBBlocks;
+import net.paddedshaman.blazingbamboo.block.BlazingBambooBlock;
 import net.paddedshaman.blazingbamboo.block.entity.BBBlockEntities;
 import net.paddedshaman.blazingbamboo.entity.BBEntities;
 import net.paddedshaman.blazingbamboo.item.BBCreativeModeTabs;
@@ -45,5 +47,14 @@ public class BlazingBamboo implements ModInitializer {
 				new BlazingBambooFeature(RandomPatchConfiguration.CODEC));
 		BiomeModifications.addFeature(BiomeSelectors.includeByKey(Biomes.CRIMSON_FOREST), GenerationStep.Decoration.VEGETAL_DECORATION,
 				ResourceKey.create(Registries.PLACED_FEATURE, new ResourceLocation(BlazingBamboo.MOD_ID, "blazing_bamboo_placed")));
+		
+		// Add Simple Copper Pipes compatibility if it is loaded
+		if (FabricLoader.getInstance().isModLoaded("copper_pipe")) {
+			net.lunade.copper.leaking_pipes.LeakingPipeDrips.register(BBBlocks.BLAZING_BAMBOO, (lava, pLevel, pPos, pState) -> {
+				if (!lava && pState.getBlock() instanceof BlazingBambooBlock bambooBlock) {
+					bambooBlock.rainOnBamboo(pLevel, pPos);
+				}
+			});
+		}
 	}
 }

--- a/src/main/java/net/paddedshaman/blazingbamboo/block/BlazingBambooBlock.java
+++ b/src/main/java/net/paddedshaman/blazingbamboo/block/BlazingBambooBlock.java
@@ -140,6 +140,12 @@ public class BlazingBambooBlock extends BambooStalkBlock {
         }
     }
 
+    public void rainOnBamboo(Level pLevel, BlockPos headBlockPos) {
+        int i = this.getHeightBelowUpToMax(pLevel, headBlockPos) + 1;
+        BlockPos baseBlockPos = headBlockPos.below(i);
+        this.extinguishBamboo(pLevel, baseBlockPos);
+    }
+
     protected void extinguishBamboo(Level pLevel, BlockPos baseBlockPos) {
         BlockState deadStalk = BBBlocks.DEAD_BAMBOO.defaultBlockState();
         int height = getHeightAboveUpToMax(pLevel, baseBlockPos);


### PR DESCRIPTION
"Simple Copper Pipes" is a Fabric exclusive mod that includes a water dripping feature that can hydrate farmland, extinguish fires, etc.

I added a small change that registers blazing bamboo as a block that Simple Copper Pipes can drip on if the Simple Copper Pipes mod is loaded.